### PR TITLE
ci: fix a failure of regular beta release CD when release notes has more than 500 chars

### DIFF
--- a/client/android/fastlane/Fastfile
+++ b/client/android/fastlane/Fastfile
@@ -31,7 +31,11 @@ platform :android do
     begin
       release_notes = generate_release_notes
 
-      File.write(release_notes_path, release_notes)
+      # Google Playのリリースノートにおける文字数制限に対応
+      trimmed_release_notes = release_notes[0...500]
+      UI.message("Trimmed release notes to 500 characters")
+
+      File.write(release_notes_path, trimmed_release_notes)
 
       build_dev
 


### PR DESCRIPTION
Fixes #20

Update `deploy_dev` lane to handle release notes with more than 500 characters.

* Trim release notes to 500 characters before writing to `metadata/android/ja-JP/changelogs/default.txt`.
* Add a comment in Japanese explaining the trimming logic.
* Ensure the logic works for release notes with less than 500 characters.
* Replace the word "truncated" with "trimmed" in the comments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shotaIDE/house-worker/pull/21?shareId=6dc80c47-af9a-46ab-b4c3-6cb3c8925a6a).